### PR TITLE
Add BoQ and inquiry service stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Tender Dashboard
+
+This project tracks tender inquiries and pricing. It consists of a Node.js backend and a React frontend.
+
+## Features
+
+The long term goal of the application is to automate the tender estimation workflow. The August timeline includes:
+
+- **Inquiry & Document Automation** – listen for inquiry emails, create project folders in Sharefile and store attachments with versioning.
+- **Measurement & BoQ Handling** – import quantities from BlueBeam exports and client provided BoQ spreadsheets, then merge them into a unified BoQ.
+- **Pricing Engine Integration** – populate unit rates from the master price sheet and calculate job totals. Custom overrides are preserved.
+- **Project CRM Dashboard** – display project status and notify the estimating team when follow up is required.
+
+The backend now contains service stubs implementing these responsibilities:
+
+- `src/services/inquiryService.js` – creates project folders and handles addenda.
+- `src/services/bluebeamParser.js` – parses BlueBeam CSV or XML measurement exports.
+- `src/services/boqService.js` – merges client BoQ data with system calculated items.
+- `src/services/pricing_engine.py` – Python helper to apply rates from the master price sheet.
+
+These modules are placeholders and can be integrated with real mailboxes and Sharefile once credentials are available.

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,10 @@
     "mongoose": "^8.15.0",
     "morgan": "^1.10.0",
     "nanoid": "^5.1.5",
-    "serverless-http": "^3.2.0"
+    "serverless-http": "^3.2.0",
+    "csv-parse": "^5.6.0",
+    "xml2js": "^0.6.2",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "serverless": "^4.14.4",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,6 +5,7 @@ import './config/db.js';           // <— just import; establishes pool
 
 import authRoutes    from './routes/auth.routes.js';
 import projectRoutes from './routes/project.routes.js';
+import boqRoutes     from './routes/boq.routes.js';
 
 const app = express();
 app.use(cors({ origin: '*', credentials: true }));
@@ -12,5 +13,6 @@ app.use(express.json());
 
 app.use('/api/auth',     authRoutes);
 app.use('/api/projects', projectRoutes);
+app.use('/api/boq',      boqRoutes);
 
 export default app;

--- a/backend/src/routes/boq.routes.js
+++ b/backend/src/routes/boq.routes.js
@@ -1,0 +1,36 @@
+// src/routes/boq.routes.js
+import { Router } from 'express';
+import { parseBoqFile, mergeBoq, importBluebeam } from '../services/boqService.js';
+import multer from 'multer';
+
+const upload = multer({ dest: 'uploads/' });
+const router = Router();
+
+// upload and parse a BoQ spreadsheet
+router.post('/upload', upload.single('file'), (req, res) => {
+  try {
+    const rows = parseBoqFile(req.file.path);
+    res.json(rows);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// merge client BoQ with system items
+router.post('/merge', (req, res) => {
+  const { clientBoq, systemItems } = req.body;
+  const merged = mergeBoq(clientBoq || [], systemItems || []);
+  res.json(merged);
+});
+
+// import measurements from BlueBeam export
+router.post('/bluebeam', upload.single('file'), async (req, res) => {
+  try {
+    const items = await importBluebeam(req.file.path);
+    res.json(items);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+export default router;

--- a/backend/src/services/bluebeamParser.js
+++ b/backend/src/services/bluebeamParser.js
@@ -1,0 +1,29 @@
+// src/services/bluebeamParser.js
+// Utilities to parse BlueBeam XML/CSV exports
+
+import fs from 'fs';
+import { parse } from 'csv-parse/sync';
+import xml2js from 'xml2js';
+
+export async function parseCSV(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const records = parse(content, { columns: true, skip_empty_lines: true });
+  return records.map(r => ({
+    description: r.Description,
+    measurement: Number(r.Measurement || 0),
+    unit: r.Units,
+    scale: r.Scale || '',
+  }));
+}
+
+export async function parseXML(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const data = await xml2js.parseStringPromise(content);
+  const items = data?.Measurements?.Item || [];
+  return items.map(i => ({
+    description: i.Description?.[0] || '',
+    measurement: Number(i.Value?.[0] || 0),
+    unit: i.Units?.[0] || '',
+    scale: i.Scale?.[0] || '',
+  }));
+}

--- a/backend/src/services/boqService.js
+++ b/backend/src/services/boqService.js
@@ -1,0 +1,39 @@
+// src/services/boqService.js
+// Handles BoQ parsing, merging and pricing
+
+import fs from 'fs';
+import * as XLSX from 'xlsx';
+import { parseCSV, parseXML } from './bluebeamParser.js';
+
+export function parseBoqFile(filePath) {
+  const wb = XLSX.readFile(filePath);
+  const ws = wb.Sheets[wb.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json(ws, { defval: '' });
+  return rows.map(r => ({
+    code: r.Code || '',
+    description: r.Description || '',
+    qty: Number(r.Quantity || 0),
+    unit: r.Unit || '',
+  }));
+}
+
+export function mergeBoq(clientBoq, systemItems) {
+  const map = new Map();
+  for (const item of systemItems) map.set(item.code, item);
+  const merged = [];
+  for (const item of clientBoq) {
+    if (map.has(item.code)) {
+      merged.push({ ...item, duplicate: true });
+      map.delete(item.code);
+    } else {
+      merged.push(item);
+    }
+  }
+  return merged.concat(Array.from(map.values()));
+}
+
+export async function importBluebeam(filePath) {
+  if (filePath.endsWith('.csv')) return parseCSV(filePath);
+  if (filePath.endsWith('.xml')) return parseXML(filePath);
+  throw new Error('Unsupported BlueBeam format');
+}

--- a/backend/src/services/inquiryService.js
+++ b/backend/src/services/inquiryService.js
@@ -1,0 +1,43 @@
+// src/services/inquiryService.js
+// Handles incoming inquiry emails and document management
+
+import fs from 'fs';
+import path from 'path';
+
+const BASE_DIR = process.env.SHAREFILE_BASE || './sharefile';
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+export function createProjectFolder(projectCode, clientName, projectType, dueDate) {
+  const folderName = `Tender_${projectCode}_${dueDate}`;
+  const folderPath = path.join(BASE_DIR, folderName);
+  ensureDir(folderPath);
+  const meta = {
+    client: clientName,
+    type: projectType,
+    due: dueDate,
+    created: new Date().toISOString(),
+  };
+  fs.writeFileSync(path.join(folderPath, 'metadata.json'), JSON.stringify(meta, null, 2));
+  return folderPath;
+}
+
+export function addAddendum(folderPath, fileName, content) {
+  ensureDir(folderPath);
+  const version = Date.now();
+  const filePath = path.join(folderPath, `${version}_${fileName}`);
+  fs.writeFileSync(filePath, content);
+  fs.writeFileSync(path.join(folderPath, 'current.txt'), fileName);
+}
+
+// Placeholder for email listener integration
+export function processEmail(msg) {
+  // msg should contain { projectCode, client, type, due, attachments: [] }
+  const folder = createProjectFolder(msg.projectCode, msg.client, msg.type, msg.due);
+  for (const att of msg.attachments || []) {
+    addAddendum(folder, att.filename, att.content);
+  }
+  return folder;
+}

--- a/backend/src/services/pricing_engine.py
+++ b/backend/src/services/pricing_engine.py
@@ -1,0 +1,38 @@
+"""pricing_engine.py
+Reads a master price Excel sheet and returns a lookup dictionary.
+This module relies on openpyxl; install via `pip install openpyxl`.
+"""
+
+from pathlib import Path
+from openpyxl import load_workbook
+
+
+def load_rates(path: str) -> dict:
+    wb = load_workbook(path, data_only=True)
+    ws = wb.active
+    rates = {}
+    for row in ws.iter_rows(min_row=2, values_only=True):
+        code, rate = row[0], row[1]
+        if code:
+            rates[str(code).strip()] = float(rate or 0)
+    return rates
+
+
+def apply_rates(boq: list, rates: dict) -> list:
+    """Populate unit rates and totals for a list of BoQ items"""
+    priced = []
+    for item in boq:
+        rate = rates.get(item.get('code'))
+        unit_rate = item.get('unit_rate') if item.get('unit_rate') is not None else rate
+        total = None
+        if unit_rate is not None and item.get('qty') is not None:
+            total = float(unit_rate) * float(item['qty'])
+        priced.append({**item, 'unit_rate': unit_rate, 'total': total})
+    return priced
+
+if __name__ == "__main__":
+    import json, sys
+    rates = load_rates(sys.argv[1])
+    items = json.load(open(sys.argv[2]))
+    priced = apply_rates(items, rates)
+    json.dump(priced, sys.stdout, indent=2)


### PR DESCRIPTION
## Summary
- document application goals in new README
- add services for parsing BlueBeam exports and BoQ spreadsheets
- create Python pricing engine module
- handle inquiry folder creation
- expose `/api/boq` routes

## Testing
- `npm --version`
- `npm --prefix backend run build` *(fails: Missing script)*