### PR TITLE
Add price list import

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ node backend/scripts/batchPrice.js ./path/to/boq1.xlsx ./path/to/boq2.xlsx
 
 Each output file is named `priced_<original>.xlsx` in the same folder.
 
+## Importing Lookalike Price Sheet
+
+The script `backend/scripts/importPriceList.js` reads the **Lookalike sheet.xlsx**
+file and stores the price items in MongoDB. Ensure `CONNECTION_STRING` is set in
+`backend/.env` then run:
+
+```bash
+npm run import-prices --prefix backend
+```
+
 ## Project API
 
 The `/api/projects` endpoints provide basic CRUD operations. When the `CONNECTION_STRING` environment variable is set, projects are stored in MongoDB. Without it, an in-memory sample list is used.

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "main": "server.js",
   "scripts": {
     "dev": "nodemon server.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "import-prices": "node scripts/importPriceList.js"
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",

--- a/backend/scripts/importPriceList.js
+++ b/backend/scripts/importPriceList.js
@@ -1,0 +1,52 @@
+import mongoose from 'mongoose';
+import XLSX from 'xlsx';
+import dotenv from 'dotenv';
+import PriceItem from '../src/models/PriceItem.js';
+
+dotenv.config();
+
+async function main() {
+  const conn = process.env.CONNECTION_STRING;
+  if (!conn) {
+    console.error('Missing CONNECTION_STRING');
+    process.exit(1);
+  }
+  await mongoose.connect(conn);
+
+  const wb = XLSX.readFile('Lookalike sheet.xlsx');
+  const ws = wb.Sheets['SERVICES'];
+  if (!ws) {
+    console.error('SERVICES sheet not found');
+    return;
+  }
+  const rows = XLSX.utils.sheet_to_json(ws, { defval: '', header: 1 });
+  const header = rows[0];
+  const items = [];
+  for (let i = 1; i < rows.length; i++) {
+    const r = rows[i];
+    if (!r || !r[0] || !r[3]) continue; // require BQ Id and description
+    const item = {
+      code: String(r[0]),
+      ref: r[1] ? String(r[1]) : undefined,
+      description: r[3],
+      unit: r[4] || undefined,
+      rate: r[6] !== '' ? Number(r[6]) : r[7] !== '' ? Number(r[7]) : undefined,
+    };
+    items.push(item);
+  }
+
+  if (items.length === 0) {
+    console.log('No items found');
+    return;
+  }
+
+  await PriceItem.deleteMany({});
+  await PriceItem.insertMany(items);
+  console.log(`Imported ${items.length} price items.`);
+  await mongoose.disconnect();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/backend/src/models/PriceItem.js
+++ b/backend/src/models/PriceItem.js
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+
+const priceItemSchema = new mongoose.Schema(
+  {
+    code: { type: String },
+    ref: { type: String },
+    description: { type: String, required: true },
+    unit: { type: String },
+    rate: { type: Number },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('PriceItem', priceItemSchema);


### PR DESCRIPTION
## Summary
- parse Lookalike sheet with a new script
- insert items into MongoDB via `PriceItem` model
- document usage in README

## Testing
- `node scripts/importPriceList.js` *(fails: querySrv ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_b_683f370e96b083258b24e893460c9fb1