### PR TITLE
Add price matching tool

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "nodemon server.js",
     "start": "node server.js",
-    "import-prices": "node scripts/importPriceList.js"
+    "import-prices": "node scripts/importPriceList.js",
+    "test": "node --test"
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -6,6 +6,7 @@ import './config/db.js';           // <— just import; establishes pool
 import authRoutes    from './routes/auth.routes.js';
 import projectRoutes from './routes/project.routes.js';
 import boqRoutes     from './routes/boq.routes.js';
+import matchRoutes   from './routes/match.routes.js';
 
 
 const app = express();
@@ -15,6 +16,7 @@ app.use(express.json());
 app.use('/api/auth',     authRoutes);
 app.use('/api/projects', projectRoutes);
 app.use('/api/boq',      boqRoutes);
+app.use('/api/match',    matchRoutes);
 
 
 export default app;

--- a/backend/src/routes/match.routes.js
+++ b/backend/src/routes/match.routes.js
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import multer from 'multer';
+import path from 'path';
+import { matchFromFiles } from '../services/matchService.js';
+
+const upload = multer({ storage: multer.memoryStorage() });
+const router = Router();
+
+const PRICE_FILE = path.resolve('frontend/MJD-PRICELIST.xlsx');
+
+router.post('/', upload.single('file'), (req, res) => {
+  if (!req.file) return res.status(400).json({ message: 'No file uploaded' });
+  try {
+    const results = matchFromFiles(PRICE_FILE, req.file.buffer);
+    res.json(results);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+export default router;

--- a/backend/src/services/matchService.js
+++ b/backend/src/services/matchService.js
@@ -1,0 +1,138 @@
+import XLSX from 'xlsx';
+
+function preprocess(text) {
+  return String(text || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function levenshtein(a, b) {
+  if (a === b) return 0;
+  const m = a.length;
+  const n = b.length;
+  const dp = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost
+      );
+    }
+  }
+  return dp[m][n];
+}
+
+function ratio(a, b) {
+  if (!a && !b) return 1;
+  const dist = levenshtein(a, b);
+  return 1 - dist / Math.max(a.length, b.length, 1);
+}
+
+function jaccard(a, b) {
+  const setA = new Set(a.split(' '));
+  const setB = new Set(b.split(' '));
+  if (!setA.size || !setB.size) return 0;
+  let inter = 0;
+  for (const v of setA) if (setB.has(v)) inter++;
+  return inter / (setA.size + setB.size - inter);
+}
+
+function detectHeader(rows) {
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i].map(v => String(v).trim());
+    if (
+      row.some(c => /description/i.test(c)) &&
+      row.some(c => /rate/i.test(c))
+    ) {
+      return { header: row, index: i };
+    }
+  }
+  return null;
+}
+
+function parseRows(rows, startIdx) {
+  const header = rows[startIdx];
+  const codeIdx = header.findIndex(h => /code|item|ref|id/i.test(h));
+  const descIdx = header.findIndex(h => /description/i.test(h));
+  const qtyIdx = header.findIndex(h => /qty|quantity/i.test(h));
+  const rateIdx = header.findIndex(h => /rate|price/i.test(h));
+
+  const items = [];
+  for (let i = startIdx + 1; i < rows.length; i++) {
+    const r = rows[i];
+    if (!r || r.every(v => v === '' || v === null)) continue;
+    const desc = r[descIdx];
+    if (!desc) continue;
+    const code = codeIdx !== -1 ? r[codeIdx] : '';
+    const qty = qtyIdx !== -1 ? Number(r[qtyIdx] || 0) : 0;
+    const rate = rateIdx !== -1 && r[rateIdx] !== '' ? Number(r[rateIdx]) : null;
+    items.push({
+      code: String(code || ''),
+      description: String(desc || ''),
+      qty,
+      rate,
+      descClean: preprocess(desc)
+    });
+  }
+  return items;
+}
+
+export function loadPriceList(path) {
+  const wb = XLSX.readFile(path);
+  const items = [];
+  for (const name of wb.SheetNames) {
+    const ws = wb.Sheets[name];
+    const rows = XLSX.utils.sheet_to_json(ws, { header: 1, defval: '' });
+    const hdr = detectHeader(rows);
+    if (!hdr) continue;
+    items.push(...parseRows(rows, hdr.index));
+  }
+  return items;
+}
+
+export function parseInputBuffer(buffer) {
+  const wb = XLSX.read(buffer, { type: 'buffer' });
+  const ws = wb.Sheets[wb.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json(ws, { header: 1, defval: '' });
+  const hdr = detectHeader(rows);
+  if (!hdr) return [];
+  return parseRows(rows, hdr.index);
+}
+
+export function matchItems(inputItems, priceItems) {
+  return inputItems.map(item => {
+    let best = null;
+    let bestScore = 0;
+    for (const p of priceItems) {
+      const s = 0.6 * ratio(item.descClean, p.descClean) +
+                0.4 * jaccard(item.descClean, p.descClean);
+      if (s > bestScore) {
+        bestScore = s;
+        best = p;
+      }
+    }
+    const rate = best && best.rate != null ? best.rate : null;
+    const total = rate != null ? rate * item.qty : null;
+    return {
+      inputDescription: item.description,
+      matchedCode: best ? best.code : '',
+      matchedDescription: best ? best.description : '',
+      quantity: item.qty,
+      unitRate: rate,
+      total,
+      confidence: Math.round(bestScore * 1000) / 1000
+    };
+  });
+}
+
+export function matchFromFiles(priceFilePath, inputBuffer) {
+  const priceItems = loadPriceList(priceFilePath);
+  const inputItems = parseInputBuffer(inputBuffer);
+  return matchItems(inputItems, priceItems);
+}

--- a/backend/test/matchService.test.js
+++ b/backend/test/matchService.test.js
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import { matchFromFiles } from '../src/services/matchService.js';
+
+const pricePath = '../frontend/MJD-PRICELIST.xlsx';
+const inputBuf = fs.readFileSync('../frontend/Input.xlsx');
+
+const results = matchFromFiles(pricePath, inputBuf);
+
+assert.ok(Array.isArray(results));
+assert.ok(results.length > 0);
+assert.ok(results[0].hasOwnProperty('inputDescription'));
+assert.ok(results[0].hasOwnProperty('confidence'));
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import ProjectOverview from './pages/ProjectOverview';
 import ProjectDocuments from './pages/ProjectDocuments';
 import ProjectBoq from './pages/ProjectBoq';
 import NewProject from './pages/NewProject';
+import PriceMatch from './pages/PriceMatch';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import { useAuth } from './hooks/useAuth';
@@ -23,6 +24,7 @@ function AuthedApp() {
             <Route path="/projects/:id" element={<ProjectOverview />} />
             <Route path="/projects/:id/documents" element={<ProjectDocuments />} />
             <Route path="/projects/:id/boq" element={<ProjectBoq />} />
+            <Route path="/price-match" element={<PriceMatch />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </main>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -10,6 +10,7 @@ export default function Sidebar() {
   const links = [
     { name: 'Projects', to: '/' },
     { name: 'New Project', to: '/new-project', icon: PlusIcon },
+    { name: 'Price Match', to: '/price-match' },
   ];
 
   return (

--- a/frontend/src/pages/PriceMatch.jsx
+++ b/frontend/src/pages/PriceMatch.jsx
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+const API_URL = import.meta.env.VITE_API_URL;
+
+export default function PriceMatch() {
+  const [rows, setRows] = useState([]);
+  const [error, setError] = useState('');
+
+  async function handleFile(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const fd = new FormData();
+    fd.append('file', file);
+    try {
+      const res = await fetch(`${API_URL}/api/match`, { method: 'POST', body: fd });
+      if (!res.ok) throw new Error('Match failed');
+      const data = await res.json();
+      setRows(data);
+      setError('');
+    } catch (err) {
+      setError(err.message);
+      setRows([]);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold text-brand-dark mb-2">Price Match</h1>
+      <input type="file" accept=".xls,.xlsx" onChange={handleFile} />
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      {rows.length > 0 && (
+        <div className="overflow-x-auto border rounded text-xs">
+          <table className="min-w-full">
+            <thead className="bg-gray-50">
+              <tr>
+                {Object.keys(rows[0]).map(h => (
+                  <th key={h} className="px-2 py-1 border-r text-left">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r, i) => (
+                <tr key={i}>
+                  {Object.values(r).map((v, j) => (
+                    <td key={j} className="px-2 py-1 border-t border-r">{v}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `matchService` to load spreadsheets and score matches
- expose new `/api/match` endpoint
- add frontend page to upload a spreadsheet and view match results
- include navigation link to new page
- add test for `matchService`

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_683f5606a7988325ae62d40810e37f07