### PR TITLE
Add CLI for Excel price matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,22 @@ Several sample files are available in `backend/pricing` for local testing:
 The file `backend/src/sampleUsers.js` provides a few demo login accounts when no database is configured. Their passwords are `password123`, `secret456` and `admin`.
 
 Set `RATE_FILE` to the path of `sample_prices.csv` to price the sample BoQ.
+
+## Price Matching
+
+The `matchExcel.js` script compares an input spreadsheet against a price list and
+prints the best match for each item along with a confidence score and rates.
+
+Run it with:
+
+```bash
+node backend/scripts/matchExcel.js frontend/MJD-PRICELIST.xlsx frontend/Input.xlsx
+```
+
+### Running tests
+
+Execute the backend unit tests with:
+
+```bash
+npm test --prefix backend
+```

--- a/backend/scripts/matchExcel.js
+++ b/backend/scripts/matchExcel.js
@@ -1,0 +1,22 @@
+import fs from 'fs';
+import path from 'path';
+import { matchFromFiles } from '../src/services/matchService.js';
+
+const [,, pricePath, inputPath] = process.argv;
+
+if (!pricePath || !inputPath) {
+  console.error('Usage: node matchExcel.js <price_list.xlsx> <input.xlsx>');
+  process.exit(1);
+}
+
+const priceFile = path.resolve(pricePath);
+const inputFile = path.resolve(inputPath);
+
+try {
+  const buf = fs.readFileSync(inputFile);
+  const results = matchFromFiles(priceFile, buf);
+  console.log(JSON.stringify(results, null, 2));
+} catch (err) {
+  console.error('Match failed:', err.message);
+  process.exit(1);
+}

--- a/backend/test/matchExcel.test.js
+++ b/backend/test/matchExcel.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'child_process';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cwd = path.resolve(__dirname, '..');
+
+const proc = spawnSync('node', [
+  'scripts/matchExcel.js',
+  '../frontend/MJD-PRICELIST.xlsx',
+  '../frontend/Input.xlsx'
+], { encoding: 'utf8', cwd });
+
+assert.strictEqual(proc.status, 0);
+const data = JSON.parse(proc.stdout);
+assert.ok(Array.isArray(data));
+assert.ok(data.length > 0);
+assert.ok(data[0].hasOwnProperty('confidence'));
+


### PR DESCRIPTION
## Summary
- add `matchExcel.js` CLI tool to match input spreadsheet rows with price list
- document usage in README and how to run tests
- add automated test for new CLI

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_683f59ea5ee8832593851140b36bf3fa