### PR TITLE
Implement price match page and fix tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Run it with:
 node backend/scripts/matchExcel.js frontend/MJD-PRICELIST.xlsx frontend/Input.xlsx
 ```
 
+### Web Interface
+
+Run the frontend with Vite and open `/price-match` to upload an Excel file for
+matching. Each row shows the best matched item from the price list along with
+its calculated rate and a confidence score.
+
 ### Running tests
 
 Execute the backend unit tests with:

--- a/backend/test/matchService.test.js
+++ b/backend/test/matchService.test.js
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
 import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { matchFromFiles } from '../src/services/matchService.js';
 
-const pricePath = '../frontend/MJD-PRICELIST.xlsx';
-const inputBuf = fs.readFileSync('../frontend/Input.xlsx');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pricePath = path.resolve(__dirname, '../../frontend/MJD-PRICELIST.xlsx');
+const inputBuf = fs.readFileSync(path.resolve(__dirname, '../../frontend/Input.xlsx'));
 
 const results = matchFromFiles(pricePath, inputBuf);
 


### PR DESCRIPTION
## Summary
- fix paths in matchService.test for node --test
- document the `/price-match` web interface in README

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_683f5dfca0b883259d4b0f0ecfc6c04f