### PR TITLE
Fix API URL fallback

### DIFF
--- a/frontend/src/components/DocumentUploader.jsx
+++ b/frontend/src/components/DocumentUploader.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
 
-const API_URL = import.meta.env.VITE_API_URL;
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
 export default function DocumentUploader({ projectId }) {
   const [files, setFiles] = useState([]);
 

--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState } from 'react';
 
-const API_URL = import.meta.env.VITE_API_URL;
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
 
 const AuthContext = createContext();
 

--- a/frontend/src/hooks/useProjects.jsx
+++ b/frontend/src/hooks/useProjects.jsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-const API_URL = import.meta.env.VITE_API_URL;
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
 
 async function fetchProjects() {
   const res = await fetch(`${API_URL}/api/projects`);

--- a/frontend/src/pages/NewProject.jsx
+++ b/frontend/src/pages/NewProject.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 
-const API_URL = import.meta.env.VITE_API_URL;
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
 
 export default function NewProject() {
   const [form, setForm] = useState({

--- a/frontend/src/pages/PriceMatch.jsx
+++ b/frontend/src/pages/PriceMatch.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-const API_URL = import.meta.env.VITE_API_URL;
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
 
 export default function PriceMatch() {
   const [rows, setRows] = useState([]);

--- a/frontend/src/pages/ProjectBoq.jsx
+++ b/frontend/src/pages/ProjectBoq.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import toast from 'react-hot-toast';
 import * as XLSX from 'xlsx';
 
-const API_URL = import.meta.env.VITE_API_URL;
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:4000';
 
 export default function ProjectBoq() {
   const { id } = useParams();


### PR DESCRIPTION
## Summary
- default to localhost when env var missing for API calls

## Testing
- `npm test --prefix backend` *(fails: TAP version 13 and hangs)*

------
https://chatgpt.com/codex/tasks/task_b_683f67a9b48883259dff85ac80af786e