### PR TITLE
Add debug logging for price match uploads

### DIFF
--- a/backend/src/routes/match.routes.js
+++ b/backend/src/routes/match.routes.js
@@ -13,10 +13,16 @@ const PRICE_FILE = path.resolve(__dirname, '../../frontend/MJD-PRICELIST.xlsx');
 
 router.post('/', upload.single('file'), (req, res) => {
   if (!req.file) return res.status(400).json({ message: 'No file uploaded' });
+  console.log('Price match upload:', {
+    name: req.file.originalname,
+    size: req.file.size
+  });
   try {
     const results = matchFromFiles(PRICE_FILE, req.file.buffer);
+    console.log('Price match results:', results.length);
     res.json(results);
   } catch (err) {
+    console.error('Price match error:', err);
     res.status(400).json({ message: err.message });
   }
 });

--- a/backend/src/services/matchService.js
+++ b/backend/src/services/matchService.js
@@ -148,6 +148,8 @@ export function matchItems(inputItems, priceItems) {
 
 export function matchFromFiles(priceFilePath, inputBuffer) {
   const priceItems = loadPriceList(priceFilePath);
+  console.log('Price list items loaded:', priceItems.length);
   const inputItems = parseInputBuffer(inputBuffer);
+  console.log('Input items parsed:', inputItems.length);
   return matchItems(inputItems, priceItems);
 }

--- a/frontend/src/pages/PriceMatch.jsx
+++ b/frontend/src/pages/PriceMatch.jsx
@@ -8,15 +8,19 @@ export default function PriceMatch() {
   async function handleFile(e) {
     const file = e.target.files[0];
     if (!file) return;
+    console.log('Uploading file', file.name, file.size);
     const fd = new FormData();
     fd.append('file', file);
     try {
       const res = await fetch(`${API_URL}/api/match`, { method: 'POST', body: fd });
+      console.log('Match response status', res.status);
       if (!res.ok) throw new Error('Match failed');
       const data = await res.json();
+      console.log('Matched rows', data.length);
       setRows(data);
       setError('');
     } catch (err) {
+      console.error('Price match error', err);
       setError(err.message);
       setRows([]);
     }


### PR DESCRIPTION
## Summary
- add console logging in `PriceMatch.jsx` during file upload
- log incoming file information and results in backend route
- log parsed item counts in `matchService`

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_683f6ef009e48325ae7cf42ed70db1ce