### PR TITLE
Fix price list path in match.routes

### DIFF
--- a/backend/src/routes/match.routes.js
+++ b/backend/src/routes/match.routes.js
@@ -9,7 +9,13 @@ const upload = multer({ storage: multer.memoryStorage() });
 const router = Router();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PRICE_FILE = path.resolve(__dirname, '../../frontend/MJD-PRICELIST.xlsx');
+// Resolve to the repo root's frontend price list file
+// Current file is located at backend/src/routes, so go up three levels
+// to reach the repo root before appending the frontend path
+const PRICE_FILE = path.resolve(
+  __dirname,
+  '../../../frontend/MJD-PRICELIST.xlsx'
+);
 
 router.post('/', upload.single('file'), (req, res) => {
   if (!req.file) return res.status(400).json({ message: 'No file uploaded' });


### PR DESCRIPTION
## Summary
- correct path to price list used in match route

## Testing
- `node backend/test/matchService.test.js` *(fails: TAP version 13 only)*

Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6840668548c883258b87167c15cb8aaa