### PR TITLE
Enhance price matching

### DIFF
--- a/backend/src/services/matchService.js
+++ b/backend/src/services/matchService.js
@@ -1,13 +1,50 @@
 import XLSX from 'xlsx';
 
+const synonymMap = {
+  bricks: 'brick',
+  brickwork: 'brick',
+  blocks: 'brick',
+  blockwork: 'brick',
+  cement: 'concrete',
+  concrete: 'concrete',
+  footing: 'foundation',
+  footings: 'foundation',
+  excavation: 'excavate',
+  excavations: 'excavate',
+  excavate: 'excavate',
+  dig: 'excavate',
+  installation: 'install',
+  installing: 'install',
+  installed: 'install',
+  demolition: 'demolish',
+  demolish: 'demolish',
+  demolishing: 'demolish',
+  remove: 'demolish',
+  supply: 'provide',
+  supplies: 'provide',
+  providing: 'provide'
+};
+
+function applySynonyms(text) {
+  return text.split(' ').map(w => {
+    const mapped = synonymMap[w];
+    if (mapped) return mapped;
+    if (w.length > 3) {
+      return w.replace(/(ings|ing|ed|es|s)$/u, '');
+    }
+    return w;
+  }).join(' ');
+}
+
 function preprocess(text) {
-  return String(text || '')
+  const cleaned = String(text || '')
     .toLowerCase()
     .replace(/[^a-z0-9\s]/g, ' ')
     .replace(/\b\d+(?:\.\d+)?\b/g, ' ') // drop standalone numbers
     .replace(/\s+(mm|cm|m|inch|in|ft)\b/g, ' ') // drop units
     .replace(/\s+/g, ' ')
     .trim();
+  return applySynonyms(cleaned);
 }
 
 function levenshtein(a, b) {
@@ -110,7 +147,7 @@ export function loadPriceList(path) {
     if (!hdr) continue;
     items.push(...parseRows(rows, hdr.index));
   }
-  return items;
+  return items.filter(it => it.rate !== null && it.rate !== undefined);
 }
 
 export function parseInputBuffer(buffer) {


### PR DESCRIPTION
## Summary
- skip price list rows without unit rates
- normalize descriptions with a small synonym map and stemming for better fuzzy matching

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_6840a1931c9483258d08aa2cb6908e40