### PR TITLE
Update price matching page

### DIFF
--- a/backend/src/services/matchService.js
+++ b/backend/src/services/matchService.js
@@ -187,7 +187,13 @@ export function loadPriceList(path) {
     if (!hdr) continue;
     items.push(...parseRows(rows, hdr.index));
   }
-  return items.filter(it => it.rate !== null && it.rate !== undefined);
+  return items.filter(
+    it =>
+      it.rate !== null &&
+      it.rate !== undefined &&
+      it.unit &&
+      String(it.unit).trim() !== ''
+  );
 }
 
 export function parseInputBuffer(buffer) {

--- a/frontend/src/pages/PriceMatch.jsx
+++ b/frontend/src/pages/PriceMatch.jsx
@@ -29,9 +29,17 @@ export default function PriceMatch() {
       if (!res.ok) throw new Error('Match failed');
       const data = await res.json();
       const formatted = data.map((r) => {
-        const first = r.matches[0] || {};
+        const matches = (r.matches || []).filter(
+          (m) =>
+            m.unit &&
+            String(m.unit).trim() !== '' &&
+            m.unitRate !== null &&
+            m.unitRate !== undefined
+        );
+        const first = matches[0] || {};
         return {
           ...r,
+          matches,
           selected: 0,
           qty: r.quantity || 0,
           code: first.code || '',
@@ -168,11 +176,10 @@ export default function PriceMatch() {
                 return (
                   <tr key={i} className="hover:bg-gray-50">
                     <td className="px-2 py-1 border-t border-r">
-                      <input
-                        type="text"
+                      <textarea
+                        readOnly
                         value={r.inputDescription}
-                        onChange={(e) => updateField(i, 'inputDescription', e.target.value)}
-                        className="w-40 border rounded px-1"
+                        className="min-w-[20rem] border rounded px-1 text-xs"
                       />
                     </td>
                     <td className="px-2 py-1 border-t border-r">
@@ -190,11 +197,10 @@ export default function PriceMatch() {
                           </label>
                         ))}
                       </div>
-                      <input
-                        type="text"
+                      <textarea
+                        readOnly
                         value={r.matchDesc}
-                        onChange={(e) => updateField(i, 'matchDesc', e.target.value)}
-                        className="w-40 border rounded px-1 mt-1"
+                        className="min-w-[20rem] border rounded px-1 mt-1 text-xs"
                       />
                       <input
                         type="text"


### PR DESCRIPTION
## Summary
- filter price list items by unit and rate on the backend
- keep only matches that include unit and rate on the price match page
- show full, read only description fields

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68418b464b5083258df835cea283af46