### PR TITLE
Move pricelist into backend and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ each item together with a confidence score and the matched unit rate.
 Run it with:
 
 ```bash
-node backend/scripts/matchExcel.js frontend/MJD-PRICELIST.xlsx frontend/Input.xlsx
+node backend/scripts/matchExcel.js backend/MJD-PRICELIST.xlsx frontend/Input.xlsx
 ```
 
 ### Web Interface

--- a/backend/src/routes/match.routes.js
+++ b/backend/src/routes/match.routes.js
@@ -12,10 +12,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // Resolve to the repo root's frontend price list file
 // Current file is located at backend/src/routes, so go up three levels
 // to reach the repo root before appending the frontend path
-const PRICE_FILE = path.resolve(
-  __dirname,
-  '../../../frontend/MJD-PRICELIST.xlsx'
-);
+const PRICE_FILE = path.resolve(__dirname, '../../MJD-PRICELIST.xlsx');
 
 router.post('/', upload.single('file'), (req, res) => {
   if (!req.file) return res.status(400).json({ message: 'No file uploaded' });

--- a/backend/test/matchExcel.test.js
+++ b/backend/test/matchExcel.test.js
@@ -8,7 +8,7 @@ const cwd = path.resolve(__dirname, '..');
 
 const proc = spawnSync('node', [
   'scripts/matchExcel.js',
-  '../frontend/MJD-PRICELIST.xlsx',
+  'MJD-PRICELIST.xlsx',
   '../frontend/Input.xlsx'
 ], { encoding: 'utf8', cwd });
 

--- a/backend/test/matchService.test.js
+++ b/backend/test/matchService.test.js
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 import { matchFromFiles } from '../src/services/matchService.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const pricePath = path.resolve(__dirname, '../../frontend/MJD-PRICELIST.xlsx');
+const pricePath = path.resolve(__dirname, '../MJD-PRICELIST.xlsx');
 const inputBuf = fs.readFileSync(path.resolve(__dirname, '../../frontend/Input.xlsx'));
 
 const results = matchFromFiles(pricePath, inputBuf);


### PR DESCRIPTION
## Summary
- move the `MJD-PRICELIST.xlsx` into the backend folder
- update code and docs to use the new location

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_6842cd57b6748325ba72a31e1d845ef0