### PR TITLE
Fix serverless YAML

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -8,7 +8,7 @@ provider:
   environment:
     CONNECTION_STRING: ${env:CONNECTION_STRING, ''}
     JWT_SECRET:        ${env:JWT_SECRET, ''}
-    JWT_REFRESH_SECRET:${env:JWT_REFRESH_SECRET, ''}
+    JWT_REFRESH_SECRET: ${env:JWT_REFRESH_SECRET, ''}
     RATE_FILE:         ${env:RATE_FILE, 'backend/MJD-PRICELIST.xlsx'}
 
   httpApi:


### PR DESCRIPTION
## Summary
- fix indentation of `JWT_REFRESH_SECRET` in `serverless.yml`

## Testing
- `npm test --prefix backend`
- `npx serverless package` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6842dd71f77483258270be4ac2642e58