### PR TITLE
Switch project to Node 22 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains a sample backend and frontend for the estimating dashboard.
 
+## Node version
+
+The project now targets **Node.js 22**. Ensure you have Node 22 installed locally when running the backend or the scripts. The deployment configuration uses the same runtime.
+
 ## Batch Pricing
 
 The script `backend/scripts/batchPrice.js` processes one or more BoQ spreadsheets and writes priced Excel files alongside the originals. It relies on the `RATE_FILE` environment variable which should point to the master price list.

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,10 +28,12 @@
   },
   "devDependencies": {
     "dotenv-cli": "^8.0.0",
-    "serverless": "^4.14.4",
-    "serverless-offline": "^14.4.0"
+    "serverless": "^4.14.4"
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "engines": {
+    "node": ">=22"
+  }
 }

--- a/backend/scripts/exportPriceList.js
+++ b/backend/scripts/exportPriceList.js
@@ -1,5 +1,5 @@
-const XLSX = require('xlsx');
-const fs = require('fs');
+import XLSX from 'xlsx';
+import fs from 'fs';
 
 const input = process.argv[2] || 'pricing/pricelist.xlsx';
 const sheet = process.argv[3] || 'SERVICES';

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -3,7 +3,7 @@ frameworkVersion: "3"
 
 provider:
   name: aws
-  runtime: nodejs18.x
+  runtime: nodejs22.x
   region: me-south-1
   environment:
     CONNECTION_STRING: ${env:CONNECTION_STRING, ''}
@@ -23,7 +23,6 @@ functions:
           method: ANY
 
 plugins:
-  - serverless-offline
   - serverless-dotenv-plugin
 
 package:

--- a/setup.sh
+++ b/setup.sh
@@ -16,7 +16,7 @@ check_internet() {
 install_node() {
   if ! command -v node >/dev/null; then
     echo "Node.js not found. Installing..."
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
     apt-get install -y nodejs
   fi
 }


### PR DESCRIPTION
## Summary
- target Node.js 22 throughout the project
- remove serverless-offline and use Express directly
- convert exportPriceList script to ESM
- update setup script to install Node 22

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_6842e37fadcc83258ec6e32ef972f47d