### PR TITLE
Use default stage

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -5,7 +5,7 @@ provider:
   name: aws
   runtime: nodejs20.x
   region: me-south-1
-  stage: ${opt:stage, 'prod'}  # 👈 Default to 'prod' if no stage is passed
+  stage: ${opt:stage, '$default'}  # Deploy to the default stage without a path prefix
   environment:
     CONNECTION_STRING: ${env:CONNECTION_STRING, ''}
     JWT_SECRET: ${env:JWT_SECRET, ''}

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-VITE_API_URL=https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com/prod
+VITE_API_URL=https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com

--- a/frontend/src/components/DocumentUploader.jsx
+++ b/frontend/src/components/DocumentUploader.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
 import toast from 'react-hot-toast';
 
-const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com/prod';
+const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com';
 export default function DocumentUploader({ projectId }) {
   const [files, setFiles] = useState([]);
 

--- a/frontend/src/hooks/useAuth.jsx
+++ b/frontend/src/hooks/useAuth.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 
-const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com/prod';
+const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com';
 
 const AuthContext = createContext();
 

--- a/frontend/src/hooks/useProjects.jsx
+++ b/frontend/src/hooks/useProjects.jsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com/prod';
+const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com';
 
 async function fetchProjects() {
   const res = await fetch(`${API_URL}/api/projects`);

--- a/frontend/src/pages/NewProject.jsx
+++ b/frontend/src/pages/NewProject.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 
-const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com/prod';
+const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com';
 
 export default function NewProject() {
   const [form, setForm] = useState({

--- a/frontend/src/pages/PriceMatch.jsx
+++ b/frontend/src/pages/PriceMatch.jsx
@@ -2,7 +2,7 @@ import { useState, useRef } from 'react';
 import * as XLSX from 'xlsx';
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
-const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com/prod';
+const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com';
 
 export default function PriceMatch() {
   const [rows, setRows] = useState([]);

--- a/frontend/src/pages/ProjectBoq.jsx
+++ b/frontend/src/pages/ProjectBoq.jsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import toast from 'react-hot-toast';
 import * as XLSX from 'xlsx';
 
-const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com/prod';
+const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com';
 
 export default function ProjectBoq() {
   const { id } = useParams();


### PR DESCRIPTION
## Summary
- deploy serverless API without a `prod` stage prefix
- update VITE_API_URL env file
- remove `/prod` fallback in frontend

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6845a48f98c08325b6eed16d4e64f754