### PR TITLE
Integrate API key input and clean OpenAI matcher

### DIFF
--- a/backend/src/routes/match.routes.js
+++ b/backend/src/routes/match.routes.js
@@ -16,9 +16,11 @@ const PRICE_FILE = path.resolve(__dirname, '../../MJD-PRICELIST.xlsx');
 
 router.post('/', upload.single('file'), (req, res) => {
   if (!req.file) return res.status(400).json({ message: 'No file uploaded' });
+  const apiKey = req.body.apiKey || '';
   console.log('Price match upload:', {
     name: req.file.originalname,
-    size: req.file.size
+    size: req.file.size,
+    apiKeyProvided: Boolean(apiKey)
   });
   try {
     const results = matchFromFiles(PRICE_FILE, req.file.buffer);

--- a/backend/src/services/matchService.js
+++ b/backend/src/services/matchService.js
@@ -246,7 +246,7 @@ export function parseInputBuffer(buffer) {
   return parseRows(rows, hdr.index);
 }
 
-export function matchItems(inputItems, priceItems, limit = 4) {
+export function matchItems(inputItems, priceItems, limit = 2) {
   function pickDiverse(sorted) {
     const out = [];
     for (const cand of sorted) {
@@ -296,5 +296,5 @@ export function matchFromFiles(priceFilePath, inputBuffer) {
   console.log('Price list items loaded:', priceItems.length);
   const inputItems = parseInputBuffer(inputBuffer);
   console.log('Input items parsed:', inputItems.length);
-  return matchItems(inputItems, priceItems, 4);
+  return matchItems(inputItems, priceItems, 2);
 }

--- a/backend/src/services/openaipricematcher.py
+++ b/backend/src/services/openaipricematcher.py
@@ -1,15 +1,3 @@
-
-
-Skip to content
-Using Gmail with screen readers
-2 of 845
-(no subject)
-Inbox
-
-Ayman Hofi <ay.hofi@gmail.com>
-02:02 (10 hours ago)
-to me
-
 import tkinter as tk
 from tkinter import filedialog, messagebox, scrolledtext
 import openai

--- a/frontend/src/pages/PriceMatch.jsx
+++ b/frontend/src/pages/PriceMatch.jsx
@@ -9,6 +9,7 @@ export default function PriceMatch() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);
+  const [apiKey, setApiKey] = useState('');
   const timerRef = useRef(null);
 
   async function handleFile(e) {
@@ -16,6 +17,9 @@ export default function PriceMatch() {
     if (!file) return;
     const fd = new FormData();
     fd.append('file', file);
+    if (apiKey) {
+      fd.append('apiKey', apiKey);
+    }
     setLoading(true);
     setProgress(0);
     timerRef.current = setInterval(() => {
@@ -138,6 +142,13 @@ export default function PriceMatch() {
   return (
     <div className="space-y-4 p-4">
       <h1 className="text-2xl font-semibold text-brand-dark mb-2">Price Match</h1>
+      <input
+        type="text"
+        placeholder="OpenAI API Key"
+        value={apiKey}
+        onChange={(e) => setApiKey(e.target.value)}
+        className="border p-1 rounded block"
+      />
       <input
         type="file"
         accept=".xls,.xlsx"


### PR DESCRIPTION
## Summary
- remove stray text from `openaipricematcher.py`
- expose API key input on price match page
- limit default matches to two in `matchService`
- log OpenAI key usage in price match route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846a4fdb6508325a972750a35b72322