### PR TITLE
Add API key admin page

### DIFF
--- a/backend/src/services/openAiService.js
+++ b/backend/src/services/openAiService.js
@@ -82,7 +82,7 @@ export async function openAiMatchFromFiles(priceFile, inputBuffer, apiKey) {
       matches: [
         {
           code: best.code,
-          description: best.description,
+          description: `${best.description} (openai)`,
           unit: best.unit,
           unitRate: best.rate,
           confidence: Math.round(bestScore * 1000) / 1000

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import ProjectDocuments from './pages/ProjectDocuments';
 import ProjectBoq from './pages/ProjectBoq';
 import NewProject from './pages/NewProject';
 import PriceMatch from './pages/PriceMatch';
+import Admin from './pages/Admin';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import { useAuth } from './hooks/useAuth';
@@ -24,6 +25,7 @@ function AuthedApp() {
           <Route path="/projects/:id/documents" element={<ProjectDocuments />} />
           <Route path="/projects/:id/boq" element={<ProjectBoq />} />
           <Route path="/price-match" element={<PriceMatch />} />
+          <Route path="/admin" element={<Admin />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </main>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -8,6 +8,7 @@ export default function Sidebar() {
     { name: 'Projects', to: '/' },
     { name: 'New Project', to: '/new-project', icon: PlusIcon },
     { name: 'Price Match', to: '/price-match' },
+    { name: 'Admin', to: '/admin' },
   ];
   return (
     <nav className="bg-brand-dark text-white flex items-center gap-6 px-6 py-3">

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+
+export default function Admin() {
+  const [openai, setOpenai] = useState('');
+  const [gemini, setGemini] = useState('');
+  const [cohere, setCohere] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    setOpenai(localStorage.getItem('openaiKey') || '');
+    setGemini(localStorage.getItem('geminiKey') || '');
+    setCohere(localStorage.getItem('cohereKey') || '');
+  }, []);
+
+  function save() {
+    localStorage.setItem('openaiKey', openai);
+    localStorage.setItem('geminiKey', gemini);
+    localStorage.setItem('cohereKey', cohere);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 1000);
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">API Keys</h1>
+      <label className="block text-sm">
+        OpenAI Key
+        <input
+          type="text"
+          value={openai}
+          onChange={(e) => setOpenai(e.target.value)}
+          className="w-full border rounded px-2 py-1 mt-1"
+        />
+      </label>
+      <label className="block text-sm">
+        Gemini Key
+        <input
+          type="text"
+          value={gemini}
+          onChange={(e) => setGemini(e.target.value)}
+          className="w-full border rounded px-2 py-1 mt-1"
+        />
+      </label>
+      <label className="block text-sm">
+        Cohere Key
+        <input
+          type="text"
+          value={cohere}
+          onChange={(e) => setCohere(e.target.value)}
+          className="w-full border rounded px-2 py-1 mt-1"
+        />
+      </label>
+      <button onClick={save} className="px-4 py-2 bg-brand-dark text-white rounded">
+        Save
+      </button>
+      {saved && <p className="text-green-600 text-sm">Saved!</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/PriceMatch.jsx
+++ b/frontend/src/pages/PriceMatch.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
 import * as XLSX from 'xlsx';
 import jsPDF from 'jspdf';
@@ -11,7 +11,7 @@ export default function PriceMatch() {
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [workbook, setWorkbook] = useState(null);
-  const [apiKey, setApiKey] = useState('');
+  const [apiKey, setApiKey] = useState(() => localStorage.getItem('openaiKey') || '');
   const timerRef = useRef(null);
   const { getRootProps, getInputProps, open, isDragActive } = useDropzone({
     onDrop: (accepted) => {
@@ -21,6 +21,10 @@ export default function PriceMatch() {
     noClick: true,
     noKeyboard: true,
   });
+
+  useEffect(() => {
+    localStorage.setItem('openaiKey', apiKey);
+  }, [apiKey]);
 
   async function handleFile(file) {
     if (!file) return;


### PR DESCRIPTION
## Summary
- add a simple Admin page for storing OpenAI, Gemini and Cohere keys
- persist OpenAI key in localStorage and reuse in Price Match page
- label OpenAI match results with `(openai)`
- wire Admin page into the sidebar and routes

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_6846af1633bc8325a0595bc2cb39b9aa