### PR TITLE
Remove API key form field and add admin link

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -8,7 +8,6 @@ export default function Sidebar() {
     { name: 'Projects', to: '/' },
     { name: 'New Project', to: '/new-project', icon: PlusIcon },
     { name: 'Price Match', to: '/price-match' },
-    { name: 'Admin', to: '/admin' },
   ];
   return (
     <nav className="bg-brand-dark text-white flex items-center gap-6 px-6 py-3">

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -3,7 +3,9 @@ import { Fragment } from 'react';
 import {
   UserCircleIcon,
   ArrowRightOnRectangleIcon,
+  Cog6ToothIcon,
 } from '@heroicons/react/24/outline';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 
 export default function TopBar() {
@@ -35,6 +37,19 @@ export default function TopBar() {
           leaveTo="transform opacity-0 scale-95"
         >
           <Menu.Items className="absolute right-0 mt-2 w-40 origin-top-right rounded-md bg-white text-black shadow-lg focus:outline-none p-1">
+            <Menu.Item>
+              {({ active }) => (
+                <Link
+                  to="/admin"
+                  className={`${
+                    active ? 'bg-gray-100' : ''
+                  } w-full flex items-center gap-2 px-4 py-2 text-sm`}
+                >
+                  <Cog6ToothIcon className="h-5 w-5" />
+                  Admin
+                </Link>
+              )}
+            </Menu.Item>
             <Menu.Item>
               {({ active }) => (
                 <button

--- a/frontend/src/pages/PriceMatch.jsx
+++ b/frontend/src/pages/PriceMatch.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef } from 'react';
 import { useDropzone } from 'react-dropzone';
 import * as XLSX from 'xlsx';
 import jsPDF from 'jspdf';
@@ -11,7 +11,6 @@ export default function PriceMatch() {
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState(0);
   const [workbook, setWorkbook] = useState(null);
-  const [apiKey, setApiKey] = useState(() => localStorage.getItem('openaiKey') || '');
   const timerRef = useRef(null);
   const { getRootProps, getInputProps, open, isDragActive } = useDropzone({
     onDrop: (accepted) => {
@@ -22,12 +21,10 @@ export default function PriceMatch() {
     noKeyboard: true,
   });
 
-  useEffect(() => {
-    localStorage.setItem('openaiKey', apiKey);
-  }, [apiKey]);
 
   async function handleFile(file) {
     if (!file) return;
+    const apiKey = localStorage.getItem('openaiKey') || '';
     const arrayBuffer = await file.arrayBuffer();
     setWorkbook(XLSX.read(arrayBuffer));
     const fd = new FormData();
@@ -165,15 +162,6 @@ export default function PriceMatch() {
   return (
     <div className="space-y-4 p-4">
       <h1 className="text-2xl font-semibold text-brand-dark mb-2">Price Match</h1>
-      <div className="mb-4">
-        <label className="block text-sm font-medium">OpenAI API Key</label>
-        <input
-          type="text"
-          value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          className="w-full border rounded px-2 py-1"
-        />
-      </div>
       <div
         {...getRootProps()}
         className={`border-2 border-dashed rounded p-6 text-center cursor-pointer ${isDragActive ? 'bg-brand-light' : ''}`}


### PR DESCRIPTION
## Summary
- rely on admin stored key for OpenAI matching
- move Admin link to the user dropdown
- remove Admin item from sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846b61331908325b80b162fb838da07