### PR TITLE
Add editable price list

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -10,6 +10,7 @@ import authRoutes from './routes/auth.routes.js';
 import projectRoutes from './routes/project.routes.js';
 import boqRoutes from './routes/boq.routes.js';
 import matchRoutes from './routes/match.routes.js';
+import priceRoutes from './routes/price.routes.js';
 
 const app = express();
 
@@ -22,5 +23,6 @@ app.use('/api/auth', authRoutes);
 app.use('/api/projects', projectRoutes);
 app.use('/api/boq', boqRoutes);
 app.use('/api/match', matchRoutes);
+app.use('/api/prices', priceRoutes);
 
 export default app;

--- a/backend/src/routes/price.routes.js
+++ b/backend/src/routes/price.routes.js
@@ -1,0 +1,34 @@
+import { Router } from 'express';
+import PriceItem from '../models/PriceItem.js';
+
+const router = Router();
+
+// List all price items
+router.get('/', async (req, res) => {
+  const items = await PriceItem.find({}).sort({ description: 1 }).lean();
+  res.json(items);
+});
+
+// Create a new price item
+router.post('/', async (req, res) => {
+  try {
+    const doc = await PriceItem.create(req.body);
+    res.status(201).json(doc);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+// Update an existing price item
+router.patch('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const doc = await PriceItem.findByIdAndUpdate(id, req.body, { new: true });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+});
+
+export default router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import ProjectDocuments from './pages/ProjectDocuments';
 import ProjectBoq from './pages/ProjectBoq';
 import NewProject from './pages/NewProject';
 import PriceMatch from './pages/PriceMatch';
+import PriceList from './pages/PriceList';
 import Admin from './pages/Admin';
 import Login from './pages/Login';
 import Register from './pages/Register';
@@ -25,6 +26,7 @@ function AuthedApp() {
           <Route path="/projects/:id/documents" element={<ProjectDocuments />} />
           <Route path="/projects/:id/boq" element={<ProjectBoq />} />
           <Route path="/price-match" element={<PriceMatch />} />
+          <Route path="/price-list" element={<PriceList />} />
           <Route path="/admin" element={<Admin />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -8,6 +8,7 @@ export default function Sidebar() {
     { name: 'Projects', to: '/' },
     { name: 'New Project', to: '/new-project', icon: PlusIcon },
     { name: 'Price Match', to: '/price-match' },
+    { name: 'Price List', to: '/price-list' },
   ];
   return (
     <nav className="bg-brand-dark text-white flex items-center gap-6 px-6 py-3">

--- a/frontend/src/hooks/usePrices.jsx
+++ b/frontend/src/hooks/usePrices.jsx
@@ -1,0 +1,29 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com';
+
+async function fetchPrices() {
+  const res = await fetch(`${API_URL}/api/prices`);
+  if (!res.ok) throw new Error('Failed to fetch prices');
+  return res.json();
+}
+
+export function usePrices() {
+  return useQuery({ queryKey: ['prices'], queryFn: fetchPrices });
+}
+
+export function useUpdatePrice() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, updates }) => {
+      const res = await fetch(`${API_URL}/api/prices/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      });
+      if (!res.ok) throw new Error('Update failed');
+      return res.json();
+    },
+    onSuccess: () => qc.invalidateQueries(['prices']),
+  });
+}

--- a/frontend/src/pages/PriceList.jsx
+++ b/frontend/src/pages/PriceList.jsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { usePrices, useUpdatePrice } from '../hooks/usePrices';
+
+export default function PriceList() {
+  const { data, isLoading, error } = usePrices();
+  const update = useUpdatePrice();
+  const [editing, setEditing] = useState({});
+
+  if (isLoading) return <p>Loading...</p>;
+  if (error) return <p className="text-red-600">{error.message}</p>;
+
+  function handleChange(id, field, value) {
+    setEditing(e => ({ ...e, [id]: { ...e[id], [field]: value } }));
+  }
+
+  function handleSave(id) {
+    update.mutate({ id, updates: editing[id] });
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-semibold text-brand-dark">Price List</h1>
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="bg-gray-100">
+            <th className="p-2 text-left">Description</th>
+            <th className="p-2 text-left">Unit</th>
+            <th className="p-2 text-left">Rate</th>
+            <th className="p-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.map(item => {
+            const values = editing[item._id] || {};
+            return (
+              <tr key={item._id} className="border-b">
+                <td className="p-2">
+                  <input
+                    className="w-full border px-2 py-1"
+                    defaultValue={item.description}
+                    onChange={e => handleChange(item._id, 'description', e.target.value)}
+                  />
+                </td>
+                <td className="p-2">
+                  <input
+                    className="w-full border px-2 py-1"
+                    defaultValue={item.unit}
+                    onChange={e => handleChange(item._id, 'unit', e.target.value)}
+                  />
+                </td>
+                <td className="p-2">
+                  <input
+                    className="w-full border px-2 py-1"
+                    defaultValue={item.rate}
+                    onChange={e => handleChange(item._id, 'rate', parseFloat(e.target.value))}
+                  />
+                </td>
+                <td className="p-2">
+                  <button
+                    onClick={() => handleSave(item._id)}
+                    className="px-3 py-1 bg-brand-accent text-white rounded"
+                  >
+                    Save
+                  </button>
+                </td>
+              </tr>
+            );
+          });
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create backend price routes
- expose price routes from Express app
- add hook and page for price list editing
- include price list tab in sidebar navigation

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_6846bcb817b8832582824a71e8716e5b