### PR TITLE
Add Cohere price matcher

### DIFF
--- a/backend/src/routes/match.routes.js
+++ b/backend/src/routes/match.routes.js
@@ -3,6 +3,7 @@ import multer from 'multer';
 import path from 'path';
 import { matchFromFiles } from '../services/matchService.js';
 import { openAiMatchFromFiles } from '../services/openAiService.js';
+import { cohereMatchFromFiles } from '../services/cohereService.js';
 import { fileURLToPath } from 'url';
 
 
@@ -21,12 +22,18 @@ router.post('/', upload.single('file'), async (req, res) => {
     name: req.file.originalname,
     size: req.file.size
   });
-  const apiKey = req.body.apiKey;
-  console.log('OpenAI key provided:', !!apiKey);
+  const { openaiKey, cohereKey } = req.body;
+  console.log('OpenAI key provided:', !!openaiKey);
+  console.log('Cohere key provided:', !!cohereKey);
   try {
-    const results = apiKey
-      ? await openAiMatchFromFiles(PRICE_FILE, req.file.buffer, apiKey)
-      : matchFromFiles(PRICE_FILE, req.file.buffer);
+    let results;
+    if (openaiKey) {
+      results = await openAiMatchFromFiles(PRICE_FILE, req.file.buffer, openaiKey);
+    } else if (cohereKey) {
+      results = await cohereMatchFromFiles(PRICE_FILE, req.file.buffer, cohereKey);
+    } else {
+      results = matchFromFiles(PRICE_FILE, req.file.buffer);
+    }
     console.log('Price match results:', results.length);
     res.json(results);
   } catch (err) {

--- a/backend/src/services/cohereService.js
+++ b/backend/src/services/cohereService.js
@@ -1,0 +1,96 @@
+import { loadPriceList, parseInputBuffer } from './matchService.js';
+
+const EMBEDDING_MODEL = process.env.COHERE_EMBEDDING_MODEL || 'embed-english-v3.0';
+const BATCH_SIZE = 96;
+const API_URL = 'https://api.cohere.ai/v1/embed';
+
+function dot(a, b) {
+  let sum = 0;
+  for (let i = 0; i < a.length; i++) sum += a[i] * b[i];
+  return sum;
+}
+
+function l2Norm(v) {
+  let sum = 0;
+  for (const x of v) sum += x * x;
+  return Math.sqrt(sum);
+}
+
+function normalize(vecs) {
+  return vecs.map(v => {
+    const n = l2Norm(v) || 1;
+    return v.map(x => x / n);
+  });
+}
+
+async function fetchEmbeddings(apiKey, texts) {
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/json'
+  };
+  const out = [];
+  for (let i = 0; i < texts.length; i += BATCH_SIZE) {
+    const batch = texts.slice(i, i + BATCH_SIZE);
+    console.log('Requesting Cohere embeddings batch', i / BATCH_SIZE + 1);
+    const res = await fetch(API_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ texts: batch, model: EMBEDDING_MODEL })
+    });
+    if (!res.ok) {
+      const msg = await res.text();
+      throw new Error(`Cohere API error: ${res.status} ${msg}`);
+    }
+    const data = await res.json();
+    if (!Array.isArray(data.embeddings)) throw new Error('Invalid Cohere response');
+    out.push(...data.embeddings);
+  }
+  return out;
+}
+
+export async function cohereMatchFromFiles(priceFile, inputBuffer, apiKey) {
+  console.log('Cohere matcher loading files');
+  const priceItems = loadPriceList(priceFile);
+  const inputItems = parseInputBuffer(inputBuffer);
+  console.log('Price items:', priceItems.length, 'Input items:', inputItems.length);
+
+  const priceTexts = priceItems.map(p => p.descClean);
+  const inputTexts = inputItems.map(i => i.descClean);
+
+  console.log('Fetching embeddings for price list');
+  const priceEmbeds = await fetchEmbeddings(apiKey, priceTexts);
+  console.log('Fetching embeddings for input items');
+  const inputEmbeds = await fetchEmbeddings(apiKey, inputTexts);
+
+  const normPrice = normalize(priceEmbeds);
+  const normInput = normalize(inputEmbeds);
+
+  console.log('Calculating similarities');
+  const results = inputItems.map((it, idx) => {
+    let bestIdx = 0;
+    let bestScore = -Infinity;
+    for (let j = 0; j < normPrice.length; j++) {
+      const s = dot(normInput[idx], normPrice[j]);
+      if (s > bestScore) {
+        bestScore = s;
+        bestIdx = j;
+      }
+    }
+    const best = priceItems[bestIdx];
+    return {
+      inputDescription: it.description,
+      quantity: it.qty,
+      matches: [
+        {
+          code: best.code,
+          description: `${best.description} (cohere)`,
+          unit: best.unit,
+          unitRate: best.rate,
+          confidence: Math.round(bestScore * 1000) / 1000
+        }
+      ]
+    };
+  });
+  console.log('Cohere matcher done');
+  return results;
+}

--- a/frontend/src/pages/PriceMatch.jsx
+++ b/frontend/src/pages/PriceMatch.jsx
@@ -24,16 +24,20 @@ export default function PriceMatch() {
 
   async function handleFile(file) {
     if (!file) return;
-    const apiKey = localStorage.getItem('openaiKey') || '';
+    const openaiKey = localStorage.getItem('openaiKey') || '';
+    const cohereKey = localStorage.getItem('cohereKey') || '';
     const arrayBuffer = await file.arrayBuffer();
     setWorkbook(XLSX.read(arrayBuffer));
     const fd = new FormData();
     fd.append('file', file);
-    if (apiKey) {
-      fd.append('apiKey', apiKey);
+    if (openaiKey) {
+      fd.append('openaiKey', openaiKey);
+    } else if (cohereKey) {
+      fd.append('cohereKey', cohereKey);
     }
     console.log('Uploading file', file.name, file.size);
-    console.log('Using API key:', apiKey ? 'yes' : 'no');
+    console.log('Using OpenAI key:', openaiKey ? 'yes' : 'no');
+    console.log('Using Cohere key:', cohereKey ? 'yes' : 'no');
     setLoading(true);
     setProgress(0);
     timerRef.current = setInterval(() => {


### PR DESCRIPTION
## Summary
- add Cohere match service
- choose matching engine in `match.routes.js`
- send selected API key from PriceMatch page

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_6846c13e02ac8325b9c5aa7c2741d5cf