### PR TITLE
Improve matcher

### DIFF
--- a/backend/src/routes/match.routes.js
+++ b/backend/src/routes/match.routes.js
@@ -1,7 +1,6 @@
 import { Router } from 'express';
 import multer from 'multer';
 import path from 'path';
-import { matchFromFiles } from '../services/matchService.js';
 import { openAiMatchFromFiles } from '../services/openAiService.js';
 import { cohereMatchFromFiles } from '../services/cohereService.js';
 import { fileURLToPath } from 'url';
@@ -32,7 +31,7 @@ router.post('/', upload.single('file'), async (req, res) => {
     } else if (cohereKey) {
       results = await cohereMatchFromFiles(PRICE_FILE, req.file.buffer, cohereKey);
     } else {
-      results = matchFromFiles(PRICE_FILE, req.file.buffer);
+      return res.status(400).json({ message: 'No API key provided' });
     }
     console.log('Price match results:', results.length);
     res.json(results);

--- a/backend/src/services/cohereService.js
+++ b/backend/src/services/cohereService.js
@@ -80,6 +80,7 @@ export async function cohereMatchFromFiles(priceFile, inputBuffer, apiKey) {
     return {
       inputDescription: it.description,
       quantity: it.qty,
+      engine: 'cohere',
       matches: [
         {
           code: best.code,

--- a/backend/src/services/openAiService.js
+++ b/backend/src/services/openAiService.js
@@ -79,6 +79,7 @@ export async function openAiMatchFromFiles(priceFile, inputBuffer, apiKey) {
     return {
       inputDescription: it.description,
       quantity: it.qty,
+      engine: 'openai',
       matches: [
         {
           code: best.code,

--- a/frontend/src/pages/PriceMatch.jsx
+++ b/frontend/src/pages/PriceMatch.jsx
@@ -65,6 +65,7 @@ export default function PriceMatch() {
           matches,
           selected: 0,
           qty: r.quantity || 0,
+          engine: r.engine || first.engine || '',
           code: first.code || '',
           matchDesc: first.description || '',
           unit: first.unit || '',
@@ -134,6 +135,7 @@ export default function PriceMatch() {
       Unit: r.unit,
       Qty: r.qty,
       Rate: r.rate,
+      Engine: r.engine,
       Confidence: r.confidence,
       Total: rowTotal(r).toFixed(2),
     }));
@@ -196,6 +198,7 @@ export default function PriceMatch() {
                 <th className="px-2 py-1 border-r text-left">Qty</th>
                 <th className="px-2 py-1 border-r text-left">Rate</th>
                 <th className="px-2 py-1 border-r text-left">Total</th>
+                <th className="px-2 py-1 border-r text-left">Engine</th>
                 <th className="px-2 py-1 border-r text-left">Conf.</th>
                 <th className="px-2 py-1 text-left">Del</th>
               </tr>
@@ -264,6 +267,7 @@ export default function PriceMatch() {
                       />
                     </td>
                     <td className="px-2 py-1 border-t border-r">{rowTotal(r).toFixed(2)}</td>
+                    <td className="px-2 py-1 border-t border-r">{r.engine}</td>
                     <td className="px-2 py-1 border-t border-r">
                       <input
                         type="number"
@@ -285,7 +289,7 @@ export default function PriceMatch() {
             </tbody>
             <tfoot>
               <tr>
-                <td colSpan="6" className="px-2 py-1 text-right font-semibold border-t">
+                <td colSpan="7" className="px-2 py-1 text-right font-semibold border-t">
                   Total
                 </td>
                 <td className="px-2 py-1 border-t border-r font-semibold">


### PR DESCRIPTION
## Summary
- use only OpenAI or Cohere matchers
- identify which engine produced a match
- expose engine info in PriceMatch UI

## Testing
- `npm test` in `backend`
- `npm test` *(fails: Missing script)* in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_6846c33049908325a9fbaf95cf64d7ef