### PR TITLE
Combine OpenAI and Cohere match results

### DIFF
--- a/backend/src/services/cohereService.js
+++ b/backend/src/services/cohereService.js
@@ -83,6 +83,7 @@ export async function cohereMatchFromFiles(priceFile, inputBuffer, apiKey) {
       engine: 'cohere',
       matches: [
         {
+          engine: 'cohere',
           code: best.code,
           description: `${best.description} (cohere)`,
           unit: best.unit,

--- a/backend/src/services/openAiService.js
+++ b/backend/src/services/openAiService.js
@@ -82,6 +82,7 @@ export async function openAiMatchFromFiles(priceFile, inputBuffer, apiKey) {
       engine: 'openai',
       matches: [
         {
+          engine: 'openai',
           code: best.code,
           description: `${best.description} (openai)`,
           unit: best.unit,

--- a/frontend/src/pages/PriceMatch.jsx
+++ b/frontend/src/pages/PriceMatch.jsx
@@ -32,7 +32,8 @@ export default function PriceMatch() {
     fd.append('file', file);
     if (openaiKey) {
       fd.append('openaiKey', openaiKey);
-    } else if (cohereKey) {
+    }
+    if (cohereKey) {
       fd.append('cohereKey', cohereKey);
     }
     console.log('Uploading file', file.name, file.size);
@@ -95,6 +96,7 @@ export default function PriceMatch() {
         return {
           ...r,
           selected: idx,
+          engine: m.engine || r.engine,
           code: m.code || '',
           matchDesc: m.description || '',
           unit: m.unit || '',


### PR DESCRIPTION
## Summary
- send both API keys from PriceMatch page
- merge OpenAI and Cohere matches in backend route
- label match engine in each match entry
- preserve selected engine on the frontend

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_6846c54f5be883258caf17956fce9e52