### PR TITLE
Improve price match UX

### DIFF
--- a/backend/src/routes/price.routes.js
+++ b/backend/src/routes/price.routes.js
@@ -9,6 +9,18 @@ router.get('/', async (req, res) => {
   res.json(items);
 });
 
+// Simple search by description
+router.get('/search', async (req, res) => {
+  const q = String(req.query.q || '').trim();
+  if (!q) return res.json([]);
+  const regex = new RegExp(q, 'i');
+  const items = await PriceItem.find({ description: regex })
+    .sort({ description: 1 })
+    .limit(20)
+    .lean();
+  res.json(items);
+});
+
 // Create a new price item
 router.post('/', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- enable searching price items via `/api/prices/search`
- allow toggling fields for editing in price match results
- add search button per row
- export Excel preserving original workbook layout
- drop PDF export option

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_6846cca9cf0c83259824e62eafb958b3