### PR TITLE
Fix body size limit for match save

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -16,7 +16,8 @@ const app = express();
 
 // ✅ Middlewares (order matters)
 app.use(cors({ origin: '*', credentials: true }));
-app.use(express.json({ strict: false })); // important for Lambda to parse body properly
+// Increase body size limit for large price match payloads
+app.use(express.json({ limit: '10mb', strict: false })); // important for Lambda to parse body properly
 
 // ✅ Routes
 app.use('/api/auth', authRoutes);


### PR DESCRIPTION
## Summary
- allow larger JSON bodies in Express to handle match results

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_6846e7da41008325af9b58d120925687