### PR TITLE
Improve price search and export

### DIFF
--- a/backend/src/routes/price.routes.js
+++ b/backend/src/routes/price.routes.js
@@ -9,12 +9,18 @@ router.get('/', async (req, res) => {
   res.json(items);
 });
 
-// Simple search by description
+// Search by code or description
 router.get('/search', async (req, res) => {
   const q = String(req.query.q || '').trim();
   if (!q) return res.json([]);
   const regex = new RegExp(q, 'i');
-  const items = await PriceItem.find({ description: regex })
+  const items = await PriceItem.find({
+    $or: [
+      { description: regex },
+      { code: regex },
+      { ref: regex }
+    ]
+  })
     .sort({ description: 1 })
     .limit(20)
     .lean();

--- a/frontend/src/hooks/usePrices.jsx
+++ b/frontend/src/hooks/usePrices.jsx
@@ -12,6 +12,18 @@ export function usePrices() {
   return useQuery({ queryKey: ['prices'], queryFn: fetchPrices });
 }
 
+export function useSearchPrices(query) {
+  return useQuery({
+    queryKey: ['prices', 'search', query],
+    queryFn: async () => {
+      const res = await fetch(`${API_URL}/api/prices/search?q=${encodeURIComponent(query)}`);
+      if (!res.ok) throw new Error('Search failed');
+      return res.json();
+    },
+    enabled: !!query
+  });
+}
+
 export function useUpdatePrice() {
   const qc = useQueryClient();
   return useMutation({

--- a/frontend/src/pages/PriceList.jsx
+++ b/frontend/src/pages/PriceList.jsx
@@ -1,8 +1,13 @@
 import { useState } from 'react';
-import { usePrices, useUpdatePrice } from '../hooks/usePrices';
+import { usePrices, useUpdatePrice, useSearchPrices } from '../hooks/usePrices';
 
 export default function PriceList() {
-  const { data, isLoading, error } = usePrices();
+  const [search, setSearch] = useState('');
+  const pricesQuery = usePrices();
+  const searchQuery = useSearchPrices(search);
+  const data = search ? searchQuery.data ?? [] : pricesQuery.data ?? [];
+  const isLoading = search ? searchQuery.isLoading : pricesQuery.isLoading;
+  const error = search ? searchQuery.error : pricesQuery.error;
   const update = useUpdatePrice();
   const [editing, setEditing] = useState({});
 
@@ -28,6 +33,15 @@ export default function PriceList() {
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-semibold text-brand-dark">Price List</h1>
+      <div>
+        <input
+          type="text"
+          placeholder="Search..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="border px-2 py-1 rounded mb-2 w-64"
+        />
+      </div>
       <table className="min-w-full text-sm">
         <thead>
           <tr className="bg-gray-100">


### PR DESCRIPTION
## Summary
- tweak price search to look by code or description
- support searching pricelist in UI
- make Excel export modify the original workbook
- disable editing for unit and confidence columns

## Testing
- `npm test --prefix backend` *(fails: `npm: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6846ea313e3883258ace625ec7a3d68a