### PR TITLE
Extend price items with categories and keywords

### DIFF
--- a/backend/scripts/importPriceList.js
+++ b/backend/scripts/importPriceList.js
@@ -21,16 +21,58 @@ async function main() {
   }
   const rows = XLSX.utils.sheet_to_json(ws, { defval: '', header: 1 });
   const header = rows[0];
+
+  const idx = {
+    code: header.findIndex(h => /bq.?id/i.test(h)),
+    ref: header.findIndex(h => /^ref/i.test(h)),
+    category: header.findIndex(h => /category/i.test(h)),
+    subCategory: header.findIndex(h => /sub.?category/i.test(h)),
+    description: header.findIndex(h => /description|desc|details/i.test(h)),
+    unit: header.findIndex(h => /^unit$/i.test(h)),
+    rate1: header.findIndex(h => /rate\s*1/i.test(h)),
+    rate2: header.findIndex(h => /rate\s*2/i.test(h)),
+    keywords: header.findIndex(h => /keyword/i.test(h)),
+    phrases: header.findIndex(h => /phrase/i.test(h)),
+  };
+
   const items = [];
   for (let i = 1; i < rows.length; i++) {
     const r = rows[i];
-    if (!r || !r[0] || !r[3]) continue; // require BQ Id and description
+    if (!r) continue;
+    const code = idx.code !== -1 ? r[idx.code] : r[0];
+    const desc = idx.description !== -1 ? r[idx.description] : r[3];
+    if (!code || !desc) continue;
     const item = {
-      code: String(r[0]),
-      ref: r[1] ? String(r[1]) : undefined,
-      description: r[3],
-      unit: r[4] || undefined,
-      rate: r[6] !== '' ? Number(r[6]) : r[7] !== '' ? Number(r[7]) : undefined,
+      code: String(code),
+      ref: idx.ref !== -1 ? (r[idx.ref] ? String(r[idx.ref]) : undefined) : undefined,
+      category: idx.category !== -1 ? r[idx.category] || undefined : undefined,
+      subCategory: idx.subCategory !== -1 ? r[idx.subCategory] || undefined : undefined,
+      description: desc,
+      unit: idx.unit !== -1 ? r[idx.unit] || undefined : r[4] || undefined,
+      rate:
+        idx.rate1 !== -1 && r[idx.rate1] !== ''
+          ? Number(r[idx.rate1])
+          : idx.rate2 !== -1 && r[idx.rate2] !== ''
+          ? Number(r[idx.rate2])
+          : r[6] !== ''
+          ? Number(r[6])
+          : r[7] !== ''
+          ? Number(r[7])
+          : undefined,
+      keywords:
+        idx.keywords !== -1 && r[idx.keywords]
+          ? String(r[idx.keywords])
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean)
+          : undefined,
+      phrases:
+        idx.phrases !== -1 && r[idx.phrases]
+          ? String(r[idx.phrases])
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean)
+          : undefined,
     };
     items.push(item);
   }

--- a/backend/src/models/PriceItem.js
+++ b/backend/src/models/PriceItem.js
@@ -5,8 +5,12 @@ const priceItemSchema = new mongoose.Schema(
     code: { type: String },
     ref: { type: String },
     description: { type: String, required: true },
+    category: { type: String },
+    subCategory: { type: String },
     unit: { type: String },
     rate: { type: Number },
+    keywords: [String],
+    phrases: [String],
   },
   { timestamps: true }
 );

--- a/backend/src/routes/price.routes.js
+++ b/backend/src/routes/price.routes.js
@@ -9,7 +9,7 @@ router.get('/', async (req, res) => {
   res.json(items);
 });
 
-// Search by code or description
+// Search by code, description or other fields
 router.get('/search', async (req, res) => {
   const q = String(req.query.q || '').trim();
   if (!q) return res.json([]);
@@ -18,7 +18,11 @@ router.get('/search', async (req, res) => {
     $or: [
       { description: regex },
       { code: regex },
-      { ref: regex }
+      { ref: regex },
+      { category: regex },
+      { subCategory: regex },
+      { keywords: regex },
+      { phrases: regex },
     ]
   })
     .sort({ description: 1 })

--- a/frontend/src/pages/PriceList.jsx
+++ b/frontend/src/pages/PriceList.jsx
@@ -26,7 +26,20 @@ export default function PriceList() {
 
   function handleSave(id) {
     if (editing[id]) {
-      update.mutate({ id, updates: editing[id] });
+      const upd = { ...editing[id] };
+      if (typeof upd.keywords === 'string') {
+        upd.keywords = upd.keywords
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean);
+      }
+      if (typeof upd.phrases === 'string') {
+        upd.phrases = upd.phrases
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean);
+      }
+      update.mutate({ id, updates: upd });
     }
   }
 
@@ -46,14 +59,27 @@ export default function PriceList() {
         <thead>
           <tr className="bg-gray-100">
             <th className="p-2 text-left">Description</th>
+            <th className="p-2 text-left">Category</th>
+            <th className="p-2 text-left">Sub Category</th>
             <th className="p-2 text-left">Unit</th>
             <th className="p-2 text-left">Rate</th>
+            <th className="p-2 text-left">Keywords</th>
+            <th className="p-2 text-left">Phrases</th>
             <th className="p-2 text-left">Actions</th>
           </tr>
         </thead>
         <tbody>
           {data.map(item => {
-            const { _id, description, unit, rate } = item;
+            const {
+              _id,
+              description,
+              category,
+              subCategory,
+              unit,
+              rate,
+              keywords = [],
+              phrases = [],
+            } = item;
             const values = editing[_id] || {};
             return (
               <tr key={_id} className="border-b">
@@ -62,6 +88,20 @@ export default function PriceList() {
                     className="w-full border px-2 py-1"
                     value={values.description ?? description}
                     onChange={e => handleChange(_id, 'description', e.target.value)}
+                  />
+                </td>
+                <td className="p-2">
+                  <input
+                    className="w-full border px-2 py-1"
+                    value={values.category ?? category}
+                    onChange={e => handleChange(_id, 'category', e.target.value)}
+                  />
+                </td>
+                <td className="p-2">
+                  <input
+                    className="w-full border px-2 py-1"
+                    value={values.subCategory ?? subCategory}
+                    onChange={e => handleChange(_id, 'subCategory', e.target.value)}
                   />
                 </td>
                 <td className="p-2">
@@ -77,6 +117,20 @@ export default function PriceList() {
                     className="w-full border px-2 py-1"
                     value={values.rate ?? rate}
                     onChange={e => handleChange(_id, 'rate', parseFloat(e.target.value))}
+                  />
+                </td>
+                <td className="p-2">
+                  <input
+                    className="w-full border px-2 py-1"
+                    value={values.keywords ?? keywords.join(', ')}
+                    onChange={e => handleChange(_id, 'keywords', e.target.value)}
+                  />
+                </td>
+                <td className="p-2">
+                  <input
+                    className="w-full border px-2 py-1"
+                    value={values.phrases ?? phrases.join(', ')}
+                    onChange={e => handleChange(_id, 'phrases', e.target.value)}
                   />
                 </td>
                 <td className="p-2">


### PR DESCRIPTION
## Summary
- allow additional fields on `PriceItem`
- import category and keyword data when present
- improve price search across extra fields
- show category, keywords and phrases in the price list UI

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_68472bb3c6ec8325b912bb46ec620070