### PR TITLE
Improve frontend user experience

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,17 +1,20 @@
-import { Routes, Route, Navigate, BrowserRouter } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { lazy, Suspense } from 'react';
 import Sidebar from './components/Sidebar';
 import TopBar from './components/TopBar';
-import Dashboard from './pages/Dashboard';
-import ProjectOverview from './pages/ProjectOverview';
-import ProjectDocuments from './pages/ProjectDocuments';
-import ProjectBoq from './pages/ProjectBoq';
-import NewProject from './pages/NewProject';
-import PriceMatch from './pages/PriceMatch';
-import PriceList from './pages/PriceList';
-import Admin from './pages/Admin';
-import Login from './pages/Login';
-import Register from './pages/Register';
+import Spinner from './components/Spinner';
 import { useAuth } from './hooks/useAuth';
+
+const Dashboard = lazy(() => import('./pages/Dashboard'));
+const ProjectOverview = lazy(() => import('./pages/ProjectOverview'));
+const ProjectDocuments = lazy(() => import('./pages/ProjectDocuments'));
+const ProjectBoq = lazy(() => import('./pages/ProjectBoq'));
+const NewProject = lazy(() => import('./pages/NewProject'));
+const PriceMatch = lazy(() => import('./pages/PriceMatch'));
+const PriceList = lazy(() => import('./pages/PriceList'));
+const Admin = lazy(() => import('./pages/Admin'));
+const Login = lazy(() => import('./pages/Login'));
+const Register = lazy(() => import('./pages/Register'));
 
 function AuthedApp() {
   return (
@@ -19,17 +22,19 @@ function AuthedApp() {
       <TopBar />
       <Sidebar />
       <main className="p-8 space-y-6 flex-1">
-        <Routes>
-          <Route index element={<Dashboard />} />
-          <Route path="/new-project" element={<NewProject />} />
-          <Route path="/projects/:id" element={<ProjectOverview />} />
-          <Route path="/projects/:id/documents" element={<ProjectDocuments />} />
-          <Route path="/projects/:id/boq" element={<ProjectBoq />} />
-          <Route path="/price-match" element={<PriceMatch />} />
-          <Route path="/price-list" element={<PriceList />} />
-          <Route path="/admin" element={<Admin />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
+        <Suspense fallback={<Spinner className="py-10" />}>
+          <Routes>
+            <Route index element={<Dashboard />} />
+            <Route path="/new-project" element={<NewProject />} />
+            <Route path="/projects/:id" element={<ProjectOverview />} />
+            <Route path="/projects/:id/documents" element={<ProjectDocuments />} />
+            <Route path="/projects/:id/boq" element={<ProjectBoq />} />
+            <Route path="/price-match" element={<PriceMatch />} />
+            <Route path="/price-list" element={<PriceList />} />
+            <Route path="/admin" element={<Admin />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </Suspense>
       </main>
     </div>
   );
@@ -37,11 +42,13 @@ function AuthedApp() {
 
 function UnauthedApp() {
   return (
-    <Routes>
-      <Route path="/login" element={<Login />} />
-      <Route path="/register" element={<Register />} />
-      <Route path="*" element={<Navigate to="/login" replace />} />
-    </Routes>
+    <Suspense fallback={<Spinner className="py-10" />}>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+        <Route path="*" element={<Navigate to="/login" replace />} />
+      </Routes>
+    </Suspense>
   );
 }
 
@@ -49,11 +56,7 @@ export default function App() {
   const { user, loading } = useAuth(); // ensure `loading` is part of your hook
 
   if (loading) {
-    return (
-      <div className="h-screen flex items-center justify-center">
-        <span className="text-gray-600">Loading...</span>
-      </div>
-    );
+    return <Spinner className="h-screen" />;
   }
 
   return user ? <AuthedApp /> : <UnauthedApp />;

--- a/frontend/src/components/SkeletonTable.jsx
+++ b/frontend/src/components/SkeletonTable.jsx
@@ -1,8 +1,8 @@
 export default function SkeletonTable() {
   return (
     <div className="animate-pulse space-y-2">
-      {Array.from({ length: 6 }).map((_, i) => (
-        <div key={i} className="h-8 bg-gray-200 rounded" />
+      {Array.from({ length: 10 }).map((_, i) => (
+        <div key={i} className="h-6 bg-gray-200 rounded" />
       ))}
     </div>
   );

--- a/frontend/src/components/Spinner.jsx
+++ b/frontend/src/components/Spinner.jsx
@@ -1,0 +1,26 @@
+export default function Spinner({ className = '' }) {
+  return (
+    <div className={`flex items-center justify-center ${className}`}>
+      <svg
+        className="animate-spin h-8 w-8 text-brand-accent"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+        />
+      </svg>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -21,36 +21,41 @@ export default function Login() {
   }
 
   return (
-    <div className="max-w-sm mx-auto mt-10 p-6 bg-white rounded shadow">
-      <h1 className="text-xl font-semibold mb-4 text-center">Login</h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="Email"
-          className="w-full border p-2 rounded"
-          required
-        />
-        <input
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder="Password"
-          className="w-full border p-2 rounded"
-          required
-        />
-        {error && <p className="text-red-600 text-sm">{error}</p>}
-        <button
-          type="submit"
-          className="w-full bg-brand-dark text-white py-2 rounded hover:opacity-90"
-        >
-          Login
-        </button>
-      </form>
-      <p className="text-sm text-center mt-3">
-        No account? <Link to="/register" className="text-brand-accent underline">Register</Link>
-      </p>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-brand-light to-white">
+      <div className="w-full max-w-sm p-8 bg-white rounded-lg shadow-xl">
+        <h1 className="text-2xl font-semibold mb-6 text-center">Login</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            className="w-full border border-gray-300 p-2 rounded focus:ring-brand-accent focus:outline-none"
+            required
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            className="w-full border border-gray-300 p-2 rounded focus:ring-brand-accent focus:outline-none"
+            required
+          />
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+          <button
+            type="submit"
+            className="w-full bg-brand-accent text-white py-2 rounded hover:bg-brand-accent/90"
+          >
+            Login
+          </button>
+        </form>
+        <p className="text-sm text-center mt-4">
+          No account?{' '}
+          <Link to="/register" className="text-brand-accent underline">
+            Register
+          </Link>
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/PriceList.jsx
+++ b/frontend/src/pages/PriceList.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { usePrices, useUpdatePrice, useSearchPrices } from '../hooks/usePrices';
+import Spinner from '../components/Spinner';
 
 export default function PriceList() {
   const [search, setSearch] = useState('');
@@ -11,7 +12,7 @@ export default function PriceList() {
   const update = useUpdatePrice();
   const [editing, setEditing] = useState({});
 
-  if (isLoading) return <p>Loading...</p>;
+  if (isLoading) return <Spinner className="py-10" />;
   if (error) return <p className="text-red-600">{error.message}</p>;
 
   function handleChange(id, field, value) {

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -22,44 +22,49 @@ export default function Register() {
   }
 
   return (
-    <div className="max-w-sm mx-auto mt-10 p-6 bg-white rounded shadow">
-      <h1 className="text-xl font-semibold mb-4 text-center">Register</h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Name"
-          className="w-full border p-2 rounded"
-          required
-        />
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="Email"
-          className="w-full border p-2 rounded"
-          required
-        />
-        <input
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          placeholder="Password"
-          className="w-full border p-2 rounded"
-          required
-        />
-        {error && <p className="text-red-600 text-sm">{error}</p>}
-        <button
-          type="submit"
-          className="w-full bg-brand-dark text-white py-2 rounded hover:opacity-90"
-        >
-          Register
-        </button>
-      </form>
-      <p className="text-sm text-center mt-3">
-        Have an account? <Link to="/login" className="text-brand-accent underline">Login</Link>
-      </p>
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-brand-light to-white">
+      <div className="w-full max-w-sm p-8 bg-white rounded-lg shadow-xl">
+        <h1 className="text-2xl font-semibold mb-6 text-center">Register</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Name"
+            className="w-full border border-gray-300 p-2 rounded focus:ring-brand-accent focus:outline-none"
+            required
+          />
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            className="w-full border border-gray-300 p-2 rounded focus:ring-brand-accent focus:outline-none"
+            required
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            className="w-full border border-gray-300 p-2 rounded focus:ring-brand-accent focus:outline-none"
+            required
+          />
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+          <button
+            type="submit"
+            className="w-full bg-brand-accent text-white py-2 rounded hover:bg-brand-accent/90"
+          >
+            Register
+          </button>
+        </form>
+        <p className="text-sm text-center mt-4">
+          Have an account?{' '}
+          <Link to="/login" className="text-brand-accent underline">
+            Login
+          </Link>
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable `<Spinner>` component
- lazy-load pages with React Suspense and show spinner fallback
- redesign login and register pages
- display spinner while price list loads
- refine skeleton table appearance

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_684740458f848325b643441d95bfe913