### PR TITLE
Fix project folder creation when creating projects

### DIFF
--- a/backend/src/routes/project.routes.js
+++ b/backend/src/routes/project.routes.js
@@ -6,6 +6,7 @@ import multer from 'multer';
 import fs from 'fs';
 import {
   getProjectFolder,
+  createProjectFolder,
   addAddendum,
   addBoqFile,
   savePricingResult,
@@ -40,6 +41,8 @@ router.post('/', async (req, res) => {
   if (process.env.CONNECTION_STRING) {
     try {
       const doc = await Project.create({ id, client, type, due });
+      // ensure folder exists for document and pricing uploads
+      createProjectFolder(id, client, type, due);
       return res.status(201).json(doc);
     } catch (err) {
       return res.status(400).json({ message: err.message });
@@ -51,6 +54,8 @@ router.post('/', async (req, res) => {
   }
   const project = { id, client, type, due, status: 'NEW' };
   sampleProjects.push(project);
+  // create folder for the new project in mock mode
+  createProjectFolder(id, client, type, due);
   res.status(201).json(project);
 });
 


### PR DESCRIPTION
## Summary
- create project folders when new projects are created
- add missing `createProjectFolder` import

## Testing
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_b_68474669dbc08325b926fe9a9fde9185