### PR TITLE
Fix project overview fetching

### DIFF
--- a/frontend/src/hooks/useProject.jsx
+++ b/frontend/src/hooks/useProject.jsx
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+
+const API_URL = import.meta.env.VITE_API_URL || 'https://2gng2p5vnc.execute-api.me-south-1.amazonaws.com';
+
+async function fetchProject(id) {
+  const res = await fetch(`${API_URL}/api/projects/${id}`);
+  if (!res.ok) throw new Error('Failed to fetch project');
+  return res.json();
+}
+
+export function useProject(id) {
+  return useQuery({
+    queryKey: ['project', id],
+    queryFn: () => fetchProject(id),
+    enabled: !!id,
+  });
+}

--- a/frontend/src/pages/ProjectOverview.jsx
+++ b/frontend/src/pages/ProjectOverview.jsx
@@ -1,14 +1,14 @@
 import { Link, useParams, useNavigate } from 'react-router-dom';
-import { sampleProjects } from '../data/sampleProjects';
 import StatusBadge from '../components/StatusBadge';
 import format from 'date-fns/format';
+import { useProject } from '../hooks/useProject';
 
 export default function ProjectOverview() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const { data: project, isLoading } = useProject(id);
 
-  // ⚠️ replace with real fetch when API is ready
-  const project = sampleProjects.find((p) => p.id === id);
+  if (isLoading) return <p className="text-gray-500">Loading…</p>;
 
   if (!project)
     return (


### PR DESCRIPTION
## Summary
- add `useProject` hook for fetching a single project
- update `ProjectOverview` to use API instead of sample data

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_684754c5a3288325ab2b23a387a301a8